### PR TITLE
Reset selected answer on question change

### DIFF
--- a/src/components/questions/QuestionSession/hooks/useAnswerProcessing.ts
+++ b/src/components/questions/QuestionSession/hooks/useAnswerProcessing.ts
@@ -129,6 +129,11 @@ export const useAnswerProcessing = (
           } else {
             // Not the last question, move to next
             setIsModalOpen(false); // Close this question to advance to next
+            
+            // Make sure to reset selection state when advancing to next question
+            setSelectedAnswerId(null);
+            setAnswerSubmitted(false);
+            setIsCorrect(false);
           }
           return prevIndex;
         });
@@ -144,6 +149,11 @@ export const useAnswerProcessing = (
       setTimeout(() => {
         setShowRelaxAnimation(false);
         setIsModalOpen(false); // Close this question to advance to next
+        
+        // Make sure to reset selection state when advancing after incorrect answer
+        setSelectedAnswerId(null);
+        setAnswerSubmitted(false);
+        setIsCorrect(false);
       }, 5000);
     }
     

--- a/src/components/questions/QuestionSession/hooks/useCurrentQuestion.ts
+++ b/src/components/questions/QuestionSession/hooks/useCurrentQuestion.ts
@@ -23,9 +23,10 @@ export const useCurrentQuestion = (
       // Check if we've reached the end of questions
       if (currentQuestionIndex >= questions.length) return;
       
-      // Reset all question state before loading the new question
+      // Complete reset of all question-related state before loading the new question
+      // This ensures no highlight persists between questions
       setAnswerSubmitted(false);
-      setSelectedAnswerId(null);
+      setSelectedAnswerId(null); // Explicitly set to null to clear any previous selection
       setIsCorrect(false);
       setShowWowEffect(false);
       
@@ -34,12 +35,14 @@ export const useCurrentQuestion = (
       setTimeRemaining(question.time_limit);
       
       // Load answer options for the new question
+      // Make sure to reset states before answer options are loaded
       await loadAnswerOptions(question.id);
       
       // Start the timer for this question
       setTimerActive(true);
     };
     
+    // Ensure we have a clean slate for the next question
     loadCurrentQuestion();
   }, [
     currentQuestionIndex, 


### PR DESCRIPTION
Resets the selected answer ID when a new question is loaded to prevent highlighting the previous answer.